### PR TITLE
FAQ: split paragraph, tweak punctuation, fix typo

### DIFF
--- a/public/static/locales/en/faq.json
+++ b/public/static/locales/en/faq.json
@@ -179,7 +179,7 @@
       "question": "Can I get rich with Circles, like the early receivers of Bitcoin?",
       "answer": [
         "Not really. Bitcoin is built like gold: it’s based on scarcity and there are a limited amount of bitcoins that will ever be created. That’s why it’s good for the purpose of storing value. Euros, Dollars, and other money systems you might be used to are very similar in this sense - their creation is limited by governments.",
-        "Circles has another approach: it is a currency designed for circulating, not for storing. We, as people, and the economy needs both types of currencies. Circles was optimized not for storing value, but for exchanging it."
+        "Circles has another approach: it is a currency designed for circulating, not for storing. We, as people, and the economy needs both types of currencies. Circles is optimized not for storing value, but for exchanging it."
       ]
     },
     {

--- a/public/static/locales/en/faq.json
+++ b/public/static/locales/en/faq.json
@@ -178,7 +178,8 @@
       "topic": "General",
       "question": "Can I get rich with Circles, like the early receivers of Bitcoin?",
       "answer": [
-        "Not really. Bitcoin is built like gold: it’s based on scarcity and there are a limited amount of bitcoins that will ever be created. That’s why it’s good for the purpose of storing value. Euros, Dollars, and other money systems you might be used to are very similar in this sense - their creation is limited by governments. Circles has another approach, it is a currency designed for circulating, not for storing. We, as people, and the economy needs both types of currencies. Circles has optimized not for storing value, but for exchanging it."
+        "Not really. Bitcoin is built like gold: it’s based on scarcity and there are a limited amount of bitcoins that will ever be created. That’s why it’s good for the purpose of storing value. Euros, Dollars, and other money systems you might be used to are very similar in this sense - their creation is limited by governments.",
+        "Circles has another approach: it is a currency designed for circulating, not for storing. We, as people, and the economy needs both types of currencies. Circles was optimized not for storing value, but for exchanging it."
       ]
     },
     {


### PR DESCRIPTION
- Changed comma to colon to avoid a comma splice
- Changed "has optimized (...) for" to "was optimized (...) for"